### PR TITLE
feat(api): return OTP session data, minor adjustments to API

### DIFF
--- a/backend/internal/api/v1/handlers/handlers_test/nomination_test.go
+++ b/backend/internal/api/v1/handlers/handlers_test/nomination_test.go
@@ -31,8 +31,8 @@ func TestNominationSubmit(t *testing.T) {
 		"zid": zid,
 		"otp": code,
 	})
-	if resp.Code != 204 {
-		t.Fatalf("expected 204 OK, got %d", resp.Code)
+	if resp.Code != 200 {
+		t.Fatalf("expected 200 OK, got %d", resp.Code)
 	}
 
 	res := resp.Result()

--- a/backend/internal/api/v1/handlers/handlers_test/otp_test.go
+++ b/backend/internal/api/v1/handlers/handlers_test/otp_test.go
@@ -1,8 +1,11 @@
 package handlers_test
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/linuxunsw/vote/backend/internal/api/v1/models"
 	"github.com/linuxunsw/vote/backend/internal/config"
 )
 
@@ -10,14 +13,30 @@ func TestOTPConsumeMember(t *testing.T) {
 	cfg := config.Load()
 	api, mailer := NewAPI(t)
 
+	then := time.Now().Add(-time.Second) // one second before
 	zid := "z0000000"
 	_ = createElection(t, api, cfg.JWT, TestingDummyJWTAdmin, []string{
 		zid,
 	})
 
 	resp := generateOTPSubmit(t, api, mailer, zid)
-	if resp.Code != 204 {
-		t.Fatalf("expected 204 OK, got %d", resp.Code)
+	if resp.Code != 200 {
+		t.Fatalf("expected 200 OK, got %d", resp.Code)
+	}
+	body := models.SubmitOTPResponseBody{};
+	err := json.Unmarshal(resp.Body.Bytes(), &body)
+	if err != nil {
+		t.Fatalf("expected body, got error %v", err)
+	}
+
+	if body.Zid != zid {
+		t.Fatalf("expected zid")
+	}
+	if body.IsAdmin {
+		t.Fatalf("expected not to be admin")
+	}
+	if body.Expiry.Before(then.Add(cfg.JWT.Duration)) {
+		t.Fatalf("expected expiry duration within 1 second")
 	}
 
 	res := resp.Result()

--- a/backend/internal/api/v1/models/election.go
+++ b/backend/internal/api/v1/models/election.go
@@ -1,6 +1,8 @@
 package models
 
-import "github.com/linuxunsw/vote/backend/internal/store"
+import (
+	"github.com/linuxunsw/vote/backend/internal/store"
+)
 
 type CreateElectionInput struct {
 	Body struct {
@@ -38,7 +40,7 @@ type GetElectionStateResponse struct {
 type GetElectionStateResponseBody struct {
 	State          string `json:"state" enum:"NO_ELECTION,CLOSED,NOMINATIONS_OPEN,NOMINATIONS_CLOSED,VOTING_OPEN,VOTING_CLOSED,RESULTS,END"`
 	ElectionId     string `json:"election_id,omitempty" doc:"Election ID. Only set if an election is running."`
-	StateCreatedAt string `json:"state_created_at,omitempty" doc:"Timestamp when the election first entered this state, in RFC3339 format. Only Set if an election is running." example:"2023-01-01T00:00:00Z"`
+	StateCreatedAt string `json:"state_created_at,omitempty" format:"date-time" example:"2024-01-15T10:30:00Z" doc:"Timestamp when the election first entered this state. Only Set if an election is running."`
 }
 
 type TransitionElectionStateInput struct {

--- a/backend/internal/api/v1/models/otp.go
+++ b/backend/internal/api/v1/models/otp.go
@@ -1,6 +1,9 @@
 package models
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 type GenerateOTPInput struct {
 	Body struct {
@@ -20,4 +23,12 @@ type SubmitOTPInput struct {
 
 type SubmitOTPResponse struct {
 	SetCookie http.Cookie `header:"Set-Cookie"`
+
+	Body SubmitOTPResponseBody
+}
+
+type SubmitOTPResponseBody struct {
+	Zid     string    `json:"zid" doc:"User zID" pattern:"^z[0-9]{7}$" example:"z0000000"`
+	Expiry  time.Time `json:"expiry" format:"date-time" example:"2024-01-15T10:30:00Z" doc:"Timestamp when your session expires."`
+	IsAdmin bool      `json:"is_admin" doc:"Admin status"`
 }

--- a/backend/internal/api/v1/routes.go
+++ b/backend/internal/api/v1/routes.go
@@ -122,7 +122,7 @@ func Register(api huma.API, deps HandlerDependencies) {
 		Method:      http.MethodPost,
 		Path:        "/elections",
 		Summary:     "Create an election",
-		Tags:        []string{"Elections"},
+		Tags:        []string{"Admin"},
 	}, handlers.CreateElection(deps.Logger, deps.ElectionStore))
 
 	huma.Register(adminRoutes, huma.Operation{
@@ -130,7 +130,7 @@ func Register(api huma.API, deps HandlerDependencies) {
 		Method:      http.MethodPut,
 		Path:        "/elections/{election_id}/members",
 		Summary:     "Set the member list for an election",
-		Tags:        []string{"Elections"},
+		Tags:        []string{"Admin"},
 	}, handlers.ElectionMemberListSet(deps.Logger, deps.ElectionStore))
 
 	huma.Register(adminRoutes, huma.Operation{

--- a/backend/internal/store/nomination_store.go
+++ b/backend/internal/store/nomination_store.go
@@ -24,7 +24,7 @@ type SubmitNomination struct {
 	DiscordUsername    string   `db:"discord_username" json:"discord_username" maxLength:"32" example:"johndoe"`
 	ExecutiveRoles     []string `db:"executive_roles" json:"executive_roles" minItems:"1" maxItems:"6" uniqueItems:"true" enum:"president,secretary,treasurer,arc_delegate,edi_officer,grievance_officer" example:"[\"president\", \"secretary\"]"`
 	CandidateStatement string   `db:"candidate_statement" json:"candidate_statement" required:"true" minLength:"50" maxLength:"2000" example:"I am running for president because..."`
-	URL                *string  `db:"url" json:"url" format:"uri" required:"false" example:"https://johndoe.com"`
+	URL                *string  `db:"url" json:"url,omitempty" format:"uri" required:"false" example:"https://johndoe.com"`
 }
 
 type NominationStore interface {


### PR DESCRIPTION
```
fix(api): elections go under `Admin`
feat(otp): add `zid`, `expiry`, `is_admin` returns from OTP submission
fix(nomination): add `omitempty` on `URL` for submission
```