### PR TITLE
feat(api): implement voting and adjusting misc endpoints

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -117,15 +117,17 @@ func main() {
 	otpStore := pg.NewPgOTPStore(pool, cfg.OTP)
 	electionStore := pg.NewPgElectionStore(pool)
 	nominationStore := pg.NewPgNominationStore(pool)
+	ballotStore := pg.NewPgBallotStore(pool)
 
 	deps := v1.HandlerDependencies{
-		Logger:        logger,
-		Cfg:           cfg,
-		Mailer:        mailer,
-		Checker:       health,
-		OtpStore:      otpStore,
-		ElectionStore: electionStore,
+		Logger:          logger,
+		Cfg:             cfg,
+		Mailer:          mailer,
+		Checker:         health,
+		OtpStore:        otpStore,
+		ElectionStore:   electionStore,
 		NominationStore: nominationStore,
+		BallotStore:     ballotStore,
 	}
 	v1.Register(api, deps)
 

--- a/backend/internal/api/v1/handlers/ballot.go
+++ b/backend/internal/api/v1/handlers/ballot.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/linuxunsw/vote/backend/internal/api/v1/middleware"
+	"github.com/linuxunsw/vote/backend/internal/api/v1/middleware/requestid"
+	"github.com/linuxunsw/vote/backend/internal/api/v1/models"
+	"github.com/linuxunsw/vote/backend/internal/store"
+)
+
+// Note that "ballots" as refered to in the backend/database actually mean "votes" in the frontend/handlers.
+// This GetBallot is actually just returning the user's submitted vote.
+func GetBallot(log *slog.Logger, st store.BallotStore, el store.ElectionStore, nom store.NominationStore) func(ctx context.Context, input *struct{}) (*models.GetBallotResponse, error) {
+	return func(ctx context.Context, input *struct{}) (*models.GetBallotResponse, error) {
+		claims, valid := middleware.GetUser(ctx)
+		if !valid {
+			log.Warn("unauthenticated user tried to get ballot", "request_id", requestid.Get(ctx))
+			return nil, huma.Error401Unauthorized("invalid user")
+		}
+
+		election, err := el.CurrentElection(ctx)
+		if err != nil {
+			log.Error("failed to get current election", "error", err, "request_id", requestid.Get(ctx))
+			return nil, huma.Error500InternalServerError("internal error")
+		}
+		if election == nil {
+			log.Warn("no current election", "request_id", requestid.Get(ctx))
+			return nil, huma.Error400BadRequest("no election is currently running")
+		}
+
+		ballot, err := st.GetBallot(ctx, election.ElectionID, claims.ZID)
+		if err != nil {
+			log.Error("failed to get ballot", "error", err, "zid", claims.ZID, "election_id", election.ElectionID, "request_id", requestid.Get(ctx))
+			return nil, huma.Error500InternalServerError("internal error")
+		}
+		// this is all we use GetBallot for
+		hasVoted := ballot != nil
+
+		// executive role -> candidates running for that role
+		candidates := make(map[string][]models.PublicNomination)
+
+		nominations, err := nom.GetElectionNominations(ctx, election.ElectionID)
+		if err != nil {
+			log.Error("failed to get nominations", "error", err, "election_id", election.ElectionID, "request_id", requestid.Get(ctx))
+			return nil, huma.Error500InternalServerError("internal error")
+		}
+		for _, nomination := range nominations {
+			for _, role := range nomination.ExecutiveRoles {
+				candidates[role] = append(candidates[role], models.FromStoreNomination(nomination))
+			}
+		}
+		response := models.PublicBallot{
+			ElectionID: election.ElectionID,
+			HasVoted:   hasVoted,
+			Candidates: candidates,
+		}
+		return &models.GetBallotResponse{Body: response}, nil
+	}
+}

--- a/backend/internal/api/v1/handlers/handlers_test/ballot_test.go
+++ b/backend/internal/api/v1/handlers/handlers_test/ballot_test.go
@@ -1,0 +1,93 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2/humatest"
+	"github.com/linuxunsw/vote/backend/internal/api/v1/models"
+	"github.com/linuxunsw/vote/backend/internal/config"
+	"github.com/linuxunsw/vote/backend/internal/mailer/mock_mailer"
+)
+
+// returns cookie header
+func cookiePer(t *testing.T, api humatest.TestAPI, mailer *mock_mailer.MockMailer, zid string, name string, roles []string) string {
+	resp := generateOTPSubmit(t, api, mailer, zid)
+	res := resp.Result()
+	cookie := extractCookieHeader(res.Header)
+
+	resp = api.Put("/api/v1/nomination", cookie, map[string]any{
+		"candidate_name":      name,
+		"contact_email":       "john@example.com",
+		"discord_username":    "johndoe#1234",
+		"executive_roles":     roles,
+		"candidate_statement": "Skibbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		"url":                 nil,
+	})
+	if resp.Code != 200 {
+		t.Fatalf("expected 200 OK, got %d", resp.Code)
+	}
+	return cookie
+}
+
+func TestBallotGet(t *testing.T) {
+	cfg := config.Load()
+	api, mailer := NewAPI(t)
+
+	_ = createElection(t, api, cfg.JWT, TestingDummyJWTAdmin, []string{
+		"z0000000",
+		"z0000001",
+		"z0000002",
+		"z0000003",
+	})
+
+	_ = cookiePer(t, api, mailer, "z0000000", "John Doe", []string{"president", "secretary"})
+	_ = cookiePer(t, api, mailer, "z0000001", "Joe Blow", []string{"president"})
+	_ = cookiePer(t, api, mailer, "z0000002", "grieve man", []string{"grievance_officer", "treasurer"})
+
+	expectedMap := map[string](map[string]bool){
+		"president":         {"John Doe": false, "Joe Blow": false},
+		"secretary":         {"John Doe": false},
+		"grievance_officer": {"grieve man": false},
+		"treasurer":         {"grieve man": false},
+	}
+
+	resp := generateOTPSubmit(t, api, mailer, "z0000003")
+	res := resp.Result()
+	cookie := extractCookieHeader(res.Header)
+
+	resp = api.Get("/api/v1/ballot", cookie)
+	if resp.Code != 200 {
+		t.Fatalf("expected 200 OK, got %d", resp.Code)
+	}
+	ballotResp := models.PublicBallot{}
+	_ = json.Unmarshal(resp.Body.Bytes(), &ballotResp)
+
+	if ballotResp.HasVoted {
+		t.Fatalf("expected HasVoted to be false, got true")
+	}
+	for role, noms := range ballotResp.Candidates {
+		expNoms, ok := expectedMap[role]
+		if !ok {
+			t.Fatalf("unexpected role %q", role)
+		}
+		for _, nom := range noms {
+			_, ok := expNoms[nom.CandidateName]
+			if !ok {
+				t.Fatalf("unexpected candidate %q for role %q", nom.CandidateName, role)
+			}
+			expNoms[nom.CandidateName] = true
+		}
+		for nom, found := range expNoms {
+			if !found {
+				t.Fatalf("expected candidate %q for role %q not found", nom, role)
+			}
+		}
+		delete(expectedMap, role)
+	}
+
+	// check if expectedMap is now empty
+	if len(expectedMap) != 0 {
+		t.Fatalf("not all expected roles found, missing: %v", expectedMap)
+	}
+}

--- a/backend/internal/api/v1/handlers/handlers_test/election_state_test.go
+++ b/backend/internal/api/v1/handlers/handlers_test/election_state_test.go
@@ -96,7 +96,7 @@ func createElectionResp(t *testing.T, api humatest.TestAPI, cfg config.JWTConfig
 func getCurrentElectionState(t *testing.T, api humatest.TestAPI, cfg config.JWTConfig, jwt string) models.GetElectionStateResponseBody {
 	adminCookie := fmt.Sprintf("Cookie: %s=%s", cfg.CookieName, jwt)
 
-	resp := api.Get("/api/v1/elections/state", adminCookie)
+	resp := api.Get("/api/v1/state", adminCookie)
 	if resp.Code != 200 {
 		t.Fatalf("expected 200 OK on get election, got %d", resp.Code)
 	}
@@ -113,7 +113,7 @@ func getCurrentElectionState(t *testing.T, api humatest.TestAPI, cfg config.JWTC
 func transitionElectionState(t *testing.T, api humatest.TestAPI, cfg config.JWTConfig, jwt string, newState string) int {
 	adminCookie := fmt.Sprintf("Cookie: %s=%s", cfg.CookieName, jwt)
 
-	resp := api.Put("/api/v1/elections/state", adminCookie, map[string]any{
+	resp := api.Put("/api/v1/state", adminCookie, map[string]any{
 		"state": newState,
 	})
 

--- a/backend/internal/api/v1/handlers/handlers_test/main_test.go
+++ b/backend/internal/api/v1/handlers/handlers_test/main_test.go
@@ -59,10 +59,12 @@ func NewAPIWithNowProvider(t *testing.T, nowProvider func() time.Time) (humatest
 	otpStore := pg.NewPgOTPStore(pool, cfg.OTP)
 	electionStore := pg.NewPgElectionStore(pool)
 	nominationStore := pg.NewPgNominationStore(pool)
+	ballotStore := pg.NewPgBallotStore(pool)
 
 	otpStore.(*pg.PgOTPStore).NowProvider = nowProvider
 	electionStore.(*pg.PgElectionStore).NowProvider = nowProvider
 	nominationStore.(*pg.PgNominationStore).NowProvider = nowProvider
+	ballotStore.(*pg.PgBallotStore).NowProvider = nowProvider
 
 	stores := v1.HandlerDependencies{
 		Logger:          logger,
@@ -72,6 +74,7 @@ func NewAPIWithNowProvider(t *testing.T, nowProvider func() time.Time) (humatest
 		OtpStore:        otpStore,
 		ElectionStore:   electionStore,
 		NominationStore: nominationStore,
+		BallotStore:     ballotStore,
 	}
 
 	v1.Register(api, stores)

--- a/backend/internal/api/v1/handlers/handlers_test/nomination_test.go
+++ b/backend/internal/api/v1/handlers/handlers_test/nomination_test.go
@@ -17,29 +17,8 @@ func TestNominationSubmit(t *testing.T) {
 		zid,
 	})
 
-	resp := api.Post("/api/v1/otp/generate", map[string]any{
-		"zid": zid,
-	})
-	// generate returns nothing, it goes to the mailer
-	if resp.Code != 204 {
-		t.Fatalf("expected 204 OK, got %d", resp.Code)
-	}
-
-	code := mailer.MockRetrieveOTP(zid + "@unsw.edu.au")
-
-	resp = api.Post("/api/v1/otp/submit", map[string]any{
-		"zid": zid,
-		"otp": code,
-	})
-	if resp.Code != 200 {
-		t.Fatalf("expected 200 OK, got %d", resp.Code)
-	}
-
+	resp := generateOTPSubmit(t, api, mailer, zid)
 	res := resp.Result()
-	if res.Header.Get("Set-Cookie") == "" {
-		t.Fatalf("expected Set-Cookie header, got none")
-	}
-
 	cookie := extractCookieHeader(res.Header)
 	resp = api.Put("/api/v1/nomination", cookie, map[string]any{
 		"candidate_name":      "John Doe",

--- a/backend/internal/api/v1/handlers/handlers_test/nomination_test.go
+++ b/backend/internal/api/v1/handlers/handlers_test/nomination_test.go
@@ -78,4 +78,13 @@ func TestNominationSubmit(t *testing.T) {
 	if err := compareStructs(nominationResp, outputNom); err != nil {
 		t.Fatal(err)
 	}
+
+	resp = api.Delete("/api/v1/nomination", cookie)
+	if resp.Code != 204 {
+		t.Fatalf("expected 204 OK, got %d", resp.Code)
+	}
+	resp = api.Delete("/api/v1/nomination", cookie)
+	if resp.Code != 204 {
+		t.Fatalf("expected 204 Not Found, got %d", resp.Code)
+	}
 }

--- a/backend/internal/api/v1/handlers/handlers_test/vote_test.go
+++ b/backend/internal/api/v1/handlers/handlers_test/vote_test.go
@@ -1,0 +1,147 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/linuxunsw/vote/backend/internal/api/v1/models"
+	"github.com/linuxunsw/vote/backend/internal/config"
+)
+
+func TestVoteSubmit(t *testing.T) {
+	nowProvider := new(func() time.Time)
+	*nowProvider = func() time.Time { return time.Now() } // dummy
+
+	cfg := config.Load()
+	api, mailer := NewAPIWithNowProvider(t, func() time.Time {
+		return (*nowProvider)()
+	})
+
+	zid0 := "z0000000"
+	zid1 := "z0000001"
+	_ = createElection(t, api, cfg.JWT, TestingDummyJWTAdmin, []string{
+		zid0,
+		zid1,
+	})
+
+	res0 := generateOTPSubmit(t, api, mailer, zid0).Result()
+	cookie0 := extractCookieHeader(res0.Header)
+	resp := api.Put("/api/v1/nomination", cookie0, map[string]any{
+		"candidate_name":      "John Doe",
+		"contact_email":       "john@example.com",
+		"discord_username":    "johndoe#1234",
+		"executive_roles":     []string{"president", "secretary"},
+		"candidate_statement": "Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50",
+		"url":                 nil,
+	})
+	if resp.Code != 204 {
+		t.Fatalf("expected 204 OK, got %d", resp.Code)
+	}
+
+	res1 := generateOTPSubmit(t, api, mailer, zid1).Result()
+	cookie1 := extractCookieHeader(res1.Header)
+
+	now0 := time.Now().Truncate(time.Second)
+	*nowProvider = func() time.Time { return now0 }
+
+	resp = api.Put("/api/v1/vote", cookie1, map[string]any{
+		"positions": map[string]string{
+			"president":  zid0,
+			"secretary": zid0,
+		},
+	})
+	if resp.Code != 204 {
+		t.Fatalf("expected 204 OK, got %d", resp.Code)
+	}
+
+	// test the time not being updated
+	now1 := time.Now().Truncate(time.Second)
+	*nowProvider = func() time.Time { return now1 }
+	
+	resp = api.Put("/api/v1/vote", cookie1, map[string]any{
+		"positions": map[string]string{
+			"president":  zid0,
+			"bogus": zid0,
+		},
+	})
+	// HTTP/1.1 422 Unprocessable Entity
+	if resp.Code != 422 {
+		// bogus
+		t.Fatalf("expected 422 Unprocessable Entity, got %d", resp.Code)
+	}
+
+	resp = api.Put("/api/v1/vote", cookie1, map[string]any{
+		"positions": map[string]string{
+			"president":  zid0,
+			"grievance_officer": zid0,
+		},
+	})
+	// HTTP/1.1 400 Bad Request
+	if resp.Code != 400 {
+		// grievance_officer not open for election
+		t.Fatalf("expected 400 Bad Request, got %d", resp.Code)
+	}
+
+	resp = api.Get("/api/v1/vote", cookie1)
+	if resp.Code != 200 {
+		t.Fatalf("expected 200 OK, got %d", resp.Code)
+	}
+	body := models.Ballot{}
+	err := json.Unmarshal(resp.Body.Bytes(), &body)
+	if err != nil {
+		t.Fatalf("expected body, got error %v", err)
+	}
+	
+	unchangedResp := models.Ballot{
+		Positions: map[string]string{
+			"president":  zid0,
+			"secretary": zid0,
+		},
+		CreatedAt: now0,
+		UpdatedAt: now0,
+	}
+	if err := compareStructs(unchangedResp, body); err != nil {
+		t.Fatal(err)
+	}
+
+	// now change the vote
+	resp = api.Put("/api/v1/vote", cookie1, map[string]any{
+		"positions": map[string]string{
+			"president":  zid0,
+			// allow putting no vote
+		},
+	})
+	if resp.Code != 204 {
+		t.Fatalf("expected 204 OK, got %d", resp.Code)
+	}
+	resp = api.Get("/api/v1/vote", cookie1)
+	if resp.Code != 200 {
+		t.Fatalf("expected 200 OK, got %d", resp.Code)
+	}
+	body = models.Ballot{}
+	err = json.Unmarshal(resp.Body.Bytes(), &body)
+	if err != nil {
+		t.Fatalf("expected body, got error %v", err)
+	}
+	changedResp := models.Ballot{
+		Positions: map[string]string{
+			"president":  zid0,
+		},
+		CreatedAt: now0,
+		UpdatedAt: now1,
+	}
+	if err := compareStructs(changedResp, body); err != nil {
+		t.Fatal(err)
+	}
+
+	// delete vote
+	resp = api.Delete("/api/v1/vote", cookie1)
+	if resp.Code != 204 {
+		t.Fatalf("expected 204 OK, got %d", resp.Code)
+	}
+	resp = api.Get("/api/v1/vote", cookie1)
+	if resp.Code != 404 {
+		t.Fatalf("expected 404 Not Found, got %d", resp.Code)
+	}
+}

--- a/backend/internal/api/v1/handlers/handlers_test/vote_test.go
+++ b/backend/internal/api/v1/handlers/handlers_test/vote_test.go
@@ -35,8 +35,8 @@ func TestVoteSubmit(t *testing.T) {
 		"candidate_statement": "Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50Deez50",
 		"url":                 nil,
 	})
-	if resp.Code != 204 {
-		t.Fatalf("expected 204 OK, got %d", resp.Code)
+	if resp.Code != 200 {
+		t.Fatalf("expected 200 OK, got %d", resp.Code)
 	}
 
 	res1 := generateOTPSubmit(t, api, mailer, zid1).Result()
@@ -87,13 +87,13 @@ func TestVoteSubmit(t *testing.T) {
 	if resp.Code != 200 {
 		t.Fatalf("expected 200 OK, got %d", resp.Code)
 	}
-	body := models.Ballot{}
+	body := models.Vote{}
 	err := json.Unmarshal(resp.Body.Bytes(), &body)
 	if err != nil {
 		t.Fatalf("expected body, got error %v", err)
 	}
 	
-	unchangedResp := models.Ballot{
+	unchangedResp := models.Vote{
 		Positions: map[string]string{
 			"president":  zid0,
 			"secretary": zid0,
@@ -119,12 +119,12 @@ func TestVoteSubmit(t *testing.T) {
 	if resp.Code != 200 {
 		t.Fatalf("expected 200 OK, got %d", resp.Code)
 	}
-	body = models.Ballot{}
+	body = models.Vote{}
 	err = json.Unmarshal(resp.Body.Bytes(), &body)
 	if err != nil {
 		t.Fatalf("expected body, got error %v", err)
 	}
-	changedResp := models.Ballot{
+	changedResp := models.Vote{
 		Positions: map[string]string{
 			"president":  zid0,
 		},

--- a/backend/internal/api/v1/handlers/vote.go
+++ b/backend/internal/api/v1/handlers/vote.go
@@ -11,8 +11,8 @@ import (
 	"github.com/linuxunsw/vote/backend/internal/store"
 )
 
-func SubmitBallot(log *slog.Logger, st store.BallotStore, el store.ElectionStore, nom store.NominationStore) func(ctx context.Context, input *models.SubmitBallotInput) (*struct{}, error) {
-	return func(ctx context.Context, input *models.SubmitBallotInput) (*struct{}, error) {
+func SubmitVote(log *slog.Logger, st store.BallotStore, el store.ElectionStore, nom store.NominationStore) func(ctx context.Context, input *models.SubmitVoteInput) (*struct{}, error) {
+	return func(ctx context.Context, input *models.SubmitVoteInput) (*struct{}, error) {
 		claims, valid := middleware.GetUser(ctx)
 		if !valid {
 			log.Warn("unauthenticated user tried to submit vote", "request_id", requestid.Get(ctx))
@@ -58,8 +58,8 @@ func SubmitBallot(log *slog.Logger, st store.BallotStore, el store.ElectionStore
 	}
 }
 
-func GetBallot(log *slog.Logger, st store.BallotStore, el store.ElectionStore) func(ctx context.Context, input *struct {}) (*models.GetBallotResponse, error) {
-	return func(ctx context.Context, input *struct {}) (*models.GetBallotResponse, error) {
+func GetVote(log *slog.Logger, st store.BallotStore, el store.ElectionStore) func(ctx context.Context, input *struct {}) (*models.GetVoteResponse, error) {
+	return func(ctx context.Context, input *struct {}) (*models.GetVoteResponse, error) {
 		claims, valid := middleware.GetUser(ctx)
 		if !valid {
 			log.Warn("unauthenticated user tried to get ballot", "request_id", requestid.Get(ctx))
@@ -84,8 +84,8 @@ func GetBallot(log *slog.Logger, st store.BallotStore, el store.ElectionStore) f
 		if ballot == nil {
 			return nil, huma.Error404NotFound("no ballot found for user")
 		}
-		return &models.GetBallotResponse{
-			Body: models.Ballot{
+		return &models.GetVoteResponse{
+			Body: models.Vote{
 				Positions: ballot.Positions,
 				CreatedAt: ballot.CreatedAt,
 				UpdatedAt: ballot.UpdatedAt,
@@ -94,7 +94,7 @@ func GetBallot(log *slog.Logger, st store.BallotStore, el store.ElectionStore) f
 	}
 }
 
-func DeleteBallot(log *slog.Logger, st store.BallotStore, el store.ElectionStore) func(ctx context.Context, input *struct {}) (*struct{}, error) {
+func DeleteVote(log *slog.Logger, st store.BallotStore, el store.ElectionStore) func(ctx context.Context, input *struct {}) (*struct{}, error) {
 	return func(ctx context.Context, input *struct {}) (*struct{}, error) {
 		claims, valid := middleware.GetUser(ctx)
 		if !valid {

--- a/backend/internal/api/v1/handlers/vote.go
+++ b/backend/internal/api/v1/handlers/vote.go
@@ -1,0 +1,122 @@
+package handlers
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/linuxunsw/vote/backend/internal/api/v1/middleware"
+	"github.com/linuxunsw/vote/backend/internal/api/v1/middleware/requestid"
+	"github.com/linuxunsw/vote/backend/internal/api/v1/models"
+	"github.com/linuxunsw/vote/backend/internal/store"
+)
+
+func SubmitBallot(log *slog.Logger, st store.BallotStore, el store.ElectionStore, nom store.NominationStore) func(ctx context.Context, input *models.SubmitBallotInput) (*struct{}, error) {
+	return func(ctx context.Context, input *models.SubmitBallotInput) (*struct{}, error) {
+		claims, valid := middleware.GetUser(ctx)
+		if !valid {
+			log.Warn("unauthenticated user tried to submit vote", "request_id", requestid.Get(ctx))
+			return nil, huma.Error401Unauthorized("invalid user")
+		}
+		
+		election, err := el.CurrentElection(ctx)
+		if err != nil {
+			log.Error("failed to get current election", "error", err, "request_id", requestid.Get(ctx))
+			return nil, huma.Error500InternalServerError("internal error")
+		}
+		if election == nil {
+			log.Warn("no current election", "request_id", requestid.Get(ctx))
+			return nil, huma.Error400BadRequest("no election is currently running")
+		}
+
+		// the keys of input.Body.Positions have been validated
+		// the values have been validated for the correct zID format, but not if they are running 
+		for position, candidateZid := range input.Body.Positions {
+			nomination, err := nom.GetNomination(ctx, election.ElectionID, candidateZid)
+			if err != nil {
+				log.Error("failed to get nomination", "error", err, "zid", candidateZid, "election_id", election.ElectionID, "request_id", requestid.Get(ctx))
+				return nil, huma.Error500InternalServerError("internal error")
+			}
+			if nomination == nil {
+				log.Warn("candidate is not running", "zid", candidateZid, "position", position, "election_id", election.ElectionID, "request_id", requestid.Get(ctx))
+				return nil, huma.Error400BadRequest("candidate is not running for position " + position)
+			}
+			if !nomination.IsRunningFor(position) {
+				log.Warn("candidate is not running for position", "zid", candidateZid, "position", position, "election_id", election.ElectionID, "request_id", requestid.Get(ctx))
+				return nil, huma.Error400BadRequest("candidate is not running for position " + position)
+			}
+		}
+
+		err = st.SubmitOrReplaceBallot(ctx, election.ElectionID, claims.ZID, store.SubmitBallot{
+			Positions: input.Body.Positions,
+		})
+		if err != nil {
+			log.Error("failed to submit ballot", "error", err, "zid", claims.ZID, "election_id", election.ElectionID, "request_id", requestid.Get(ctx))
+			return nil, huma.Error500InternalServerError("internal error")
+		}
+		return &struct{}{}, nil
+	}
+}
+
+func GetBallot(log *slog.Logger, st store.BallotStore, el store.ElectionStore) func(ctx context.Context, input *struct {}) (*models.GetBallotResponse, error) {
+	return func(ctx context.Context, input *struct {}) (*models.GetBallotResponse, error) {
+		claims, valid := middleware.GetUser(ctx)
+		if !valid {
+			log.Warn("unauthenticated user tried to get ballot", "request_id", requestid.Get(ctx))
+			return nil, huma.Error401Unauthorized("invalid user")
+		}
+
+		election, err := el.CurrentElection(ctx)
+		if err != nil {
+			log.Error("failed to get current election", "error", err, "request_id", requestid.Get(ctx))
+			return nil, huma.Error500InternalServerError("internal error")
+		}
+		if election == nil {
+			log.Warn("no current election", "request_id", requestid.Get(ctx))
+			return nil, huma.Error400BadRequest("no election is currently running")
+		}
+
+		ballot, err := st.GetBallot(ctx, election.ElectionID, claims.ZID)
+		if err != nil {
+			log.Error("failed to get ballot", "error", err, "zid", claims.ZID, "election_id", election.ElectionID, "request_id", requestid.Get(ctx))
+			return nil, huma.Error500InternalServerError("internal error")
+		}
+		if ballot == nil {
+			return nil, huma.Error404NotFound("no ballot found for user")
+		}
+		return &models.GetBallotResponse{
+			Body: models.Ballot{
+				Positions: ballot.Positions,
+				CreatedAt: ballot.CreatedAt,
+				UpdatedAt: ballot.UpdatedAt,
+			},
+		}, nil
+	}
+}
+
+func DeleteBallot(log *slog.Logger, st store.BallotStore, el store.ElectionStore) func(ctx context.Context, input *struct {}) (*struct{}, error) {
+	return func(ctx context.Context, input *struct {}) (*struct{}, error) {
+		claims, valid := middleware.GetUser(ctx)
+		if !valid {
+			log.Warn("unauthenticated user tried to delete ballot", "request_id", requestid.Get(ctx))
+			return nil, huma.Error401Unauthorized("invalid user")
+		}
+
+		election, err := el.CurrentElection(ctx)
+		if err != nil {
+			log.Error("failed to get current election", "error", err, "request_id", requestid.Get(ctx))
+			return nil, huma.Error500InternalServerError("internal error")
+		}
+		if election == nil {
+			log.Warn("no current election", "request_id", requestid.Get(ctx))
+			return nil, huma.Error400BadRequest("no election is currently running")
+		}
+
+		err = st.TryDeleteBallot(ctx, election.ElectionID, claims.ZID)
+		if err != nil {
+			log.Error("failed to delete ballot", "error", err, "zid", claims.ZID, "election_id", election.ElectionID, "request_id", requestid.Get(ctx))
+			return nil, huma.Error500InternalServerError("internal error")
+		}
+		return &struct{}{}, nil
+	}
+}

--- a/backend/internal/api/v1/handlers/vote.go
+++ b/backend/internal/api/v1/handlers/vote.go
@@ -31,18 +31,18 @@ func SubmitVote(log *slog.Logger, st store.BallotStore, el store.ElectionStore, 
 
 		// the keys of input.Body.Positions have been validated
 		// the values have been validated for the correct zID format, but not if they are running 
-		for position, candidateZid := range input.Body.Positions {
-			nomination, err := nom.GetNomination(ctx, election.ElectionID, candidateZid)
+		for position, nominationId := range input.Body.Positions {
+			nomination, err := nom.GetNominationByPublicId(ctx, nominationId)
 			if err != nil {
-				log.Error("failed to get nomination", "error", err, "zid", candidateZid, "election_id", election.ElectionID, "request_id", requestid.Get(ctx))
+				log.Error("failed to get nomination", "error", err, "nomination_id", nominationId, "election_id", election.ElectionID, "request_id", requestid.Get(ctx))
 				return nil, huma.Error500InternalServerError("internal error")
 			}
 			if nomination == nil {
-				log.Warn("candidate is not running", "zid", candidateZid, "position", position, "election_id", election.ElectionID, "request_id", requestid.Get(ctx))
+				log.Warn("candidate is not running", "nomination_id", nominationId, "position", position, "election_id", election.ElectionID, "request_id", requestid.Get(ctx))
 				return nil, huma.Error400BadRequest("candidate is not running for position " + position)
 			}
 			if !nomination.IsRunningFor(position) {
-				log.Warn("candidate is not running for position", "zid", candidateZid, "position", position, "election_id", election.ElectionID, "request_id", requestid.Get(ctx))
+				log.Warn("candidate is not running for position", "nomination_id", nominationId, "position", position, "election_id", election.ElectionID, "request_id", requestid.Get(ctx))
 				return nil, huma.Error400BadRequest("candidate is not running for position " + position)
 			}
 		}

--- a/backend/internal/api/v1/models/ballot.go
+++ b/backend/internal/api/v1/models/ballot.go
@@ -1,0 +1,11 @@
+package models
+
+type PublicBallot struct {
+	ElectionID string                        `json:"election_id" example:"1" doc:"Election ID"`
+	Candidates map[string][]PublicNomination `json:"candidates" doc:"Map of executive role to list of candidates running for that role" example:"{\"president\": [], \"secretary\": []}"`
+	HasVoted   bool                          `json:"has_voted" doc:"Whether the current user has already voted in this election"`
+}
+
+type GetBallotResponse struct {
+	Body PublicBallot
+}

--- a/backend/internal/api/v1/models/nomination.go
+++ b/backend/internal/api/v1/models/nomination.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"net/url"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/linuxunsw/vote/backend/internal/store"
@@ -40,16 +41,47 @@ func (b *SubmitNominationRequest) Resolve(ctx huma.Context) []error {
 	return nil
 }
 
+type SubmitNominationResponse struct {
+	Body SubmitNominationResponseBody
+}
+
+type SubmitNominationResponseBody struct {
+	NominationID string `json:"nomination_id" example:"abc123" doc:"Public nomination ID"`
+}
+
+// Public nominations don't have zID or contact email
+type PublicNomination struct {
+	ElectionID         string    `json:"election_id" example:"1"`
+	CandidateName      string    `json:"candidate_name" example:"John Doe"`
+	DiscordUsername    string    `json:"discord_username" example:"johndoe"`
+	ExecutiveRoles     []string  `json:"executive_roles" example:"[\"president\", \"secretary\"]"`
+	CandidateStatement string    `json:"candidate_statement" example:"I am running for president because..."`
+	URL                *string   `json:"url,omitempty" example:"https://johndoe.com"`
+	CreatedAt          time.Time `json:"created_at" format:"date-time" example:"2024-01-15T10:30:00Z"`
+	UpdatedAt          time.Time `json:"updated_at" format:"date-time" example:"2024-01-15T10:30:00Z"`
+}
+
+func FromStoreNomination(nom store.Nomination) PublicNomination {
+	return PublicNomination{
+		ElectionID:         nom.ElectionID,
+		CandidateName:      nom.CandidateName,
+		DiscordUsername:    nom.DiscordUsername,
+		ExecutiveRoles:     nom.ExecutiveRoles,
+		CandidateStatement: nom.CandidateStatement,
+		URL:                nom.URL,
+		CreatedAt:          nom.CreatedAt,
+		UpdatedAt:          nom.UpdatedAt,
+	}
+}
+
 type GetNominationResponse struct {
 	Body store.Nomination
 }
 
-type PublicNominationResponse struct {
-	Body struct {
-		CandidateName      string   `json:"candidate_name" example:"John Doe"`
-		DiscordUsername    string   `json:"discord_username,omitempty" example:"johndoe"`
-		ExecutiveRoles     []string `json:"executive_roles" example:"[\"president\", \"secretary\"]"`
-		CandidateStatement string   `json:"candidate_statement" example:"I am running for president because..."`
-		URL                *string  `json:"url,omitempty" format:"uri" example:"https://johndoe.com"`
-	}
+type GetPublicNominationInput struct {
+	NominationId string `path:"nomination_id" doc:"Public nomination ID"`
+}
+
+type GetPublicNominationResponse struct {
+	Body PublicNomination
 }

--- a/backend/internal/api/v1/models/nomination.go
+++ b/backend/internal/api/v1/models/nomination.go
@@ -51,7 +51,8 @@ type SubmitNominationResponseBody struct {
 
 // Public nominations don't have zID or contact email
 type PublicNomination struct {
-	ElectionID         string    `json:"election_id" example:"1"`
+	NominationId       string    `json:"nomination_id"`
+	ElectionID         string    `json:"election_id"`
 	CandidateName      string    `json:"candidate_name" example:"John Doe"`
 	DiscordUsername    string    `json:"discord_username" example:"johndoe"`
 	ExecutiveRoles     []string  `json:"executive_roles" example:"[\"president\", \"secretary\"]"`
@@ -63,6 +64,7 @@ type PublicNomination struct {
 
 func FromStoreNomination(nom store.Nomination) PublicNomination {
 	return PublicNomination{
+		NominationId:       nom.NominationId,
 		ElectionID:         nom.ElectionID,
 		CandidateName:      nom.CandidateName,
 		DiscordUsername:    nom.DiscordUsername,

--- a/backend/internal/api/v1/models/vote.go
+++ b/backend/internal/api/v1/models/vote.go
@@ -7,8 +7,8 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 )
 
-type SubmitBallotInput struct {
-	Body SubmitBallotBody
+type SubmitVoteInput struct {
+	Body SubmitVoteBody
 }
 
 // president,secretary,treasurer,arc_delegate,edi_officer,grievance_officer
@@ -24,11 +24,11 @@ var validPositions = map[string]struct{}{
 
 var zIDRegex = regexp.MustCompile(`^z[0-9]{7}$`)
 
-type SubmitBallotBody struct {
+type SubmitVoteBody struct {
 	Positions map[string]string `json:"positions" example:"{\"president\":\"z1234567\",\"secretary\":\"z7654321\"}"`
 }
 
-func (b *SubmitBallotInput) Resolve(ctx huma.Context) []error {
+func (b *SubmitVoteInput) Resolve(ctx huma.Context) []error {
 	var errors []error
 
 	for position, zid := range b.Body.Positions {
@@ -51,11 +51,11 @@ func (b *SubmitBallotInput) Resolve(ctx huma.Context) []error {
 	return errors
 }
 
-type GetBallotResponse struct {
-	Body Ballot
+type GetVoteResponse struct {
+	Body Vote
 }
 
-type Ballot struct {
+type Vote struct {
 	Positions map[string]string `json:"positions" example:"{\"president\":\"z1234567\",\"secretary\":\"z7654321\"}"`
 	CreatedAt time.Time            `json:"created_at" format:"date-time" example:"2024-01-15T10:30:00Z"`
 	UpdatedAt time.Time            `json:"updated_at" format:"date-time" example:"2024-01-15T10:30:00Z"`

--- a/backend/internal/api/v1/models/vote.go
+++ b/backend/internal/api/v1/models/vote.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"regexp"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -22,8 +21,6 @@ var validPositions = map[string]struct{}{
 	"grievance_officer": {},
 }
 
-var zIDRegex = regexp.MustCompile(`^z[0-9]{7}$`)
-
 type SubmitVoteBody struct {
 	Positions map[string]string `json:"positions" example:"{\"president\":\"z1234567\",\"secretary\":\"z7654321\"}"`
 }
@@ -31,19 +28,12 @@ type SubmitVoteBody struct {
 func (b *SubmitVoteInput) Resolve(ctx huma.Context) []error {
 	var errors []error
 
-	for position, zid := range b.Body.Positions {
+	for position := range b.Body.Positions {
 		if _, ok := validPositions[position]; !ok {
 			errors = append(errors, &huma.ErrorDetail{
 				Message:  "invalid position",
 				Location: "body.positions",
 				Value:    position,
-			})
-		}
-		if !zIDRegex.MatchString(zid) {
-			errors = append(errors, &huma.ErrorDetail{
-				Message:  "invalid zid format",
-				Location: "body.positions." + position,
-				Value:    zid,
 			})
 		}
 	}
@@ -56,7 +46,7 @@ type GetVoteResponse struct {
 }
 
 type Vote struct {
-	Positions map[string]string `json:"positions" example:"{\"president\":\"z1234567\",\"secretary\":\"z7654321\"}"`
-	CreatedAt time.Time            `json:"created_at" format:"date-time" example:"2024-01-15T10:30:00Z"`
-	UpdatedAt time.Time            `json:"updated_at" format:"date-time" example:"2024-01-15T10:30:00Z"`
+	Positions map[string]string `json:"positions" doc:"A map from categories to public nomination IDs. Find these by accessing your ballot." example:"{\"president\":\"01996ae6-31e5-7bc6-bac4-399ffc8c80de\",\"secretary\":\"01996ae6-31e5-7bc6-bac4-399ffc8c80de\"}"`
+	CreatedAt time.Time         `json:"created_at" format:"date-time" example:"2024-01-15T10:30:00Z"`
+	UpdatedAt time.Time         `json:"updated_at" format:"date-time" example:"2024-01-15T10:30:00Z"`
 }

--- a/backend/internal/api/v1/models/vote.go
+++ b/backend/internal/api/v1/models/vote.go
@@ -22,7 +22,7 @@ var validPositions = map[string]struct{}{
 }
 
 type SubmitVoteBody struct {
-	Positions map[string]string `json:"positions" example:"{\"president\":\"z1234567\",\"secretary\":\"z7654321\"}"`
+	Positions map[string]string `json:"positions" doc:"A map from categories to public nomination IDs. Find these by accessing your ballot." example:"{\"president\":\"01996ae6-31e5-7bc6-bac4-399ffc8c80de\",\"secretary\":\"01996ae6-31e5-7bc6-bac4-399ffc8c80de\"}"`
 }
 
 func (b *SubmitVoteInput) Resolve(ctx huma.Context) []error {

--- a/backend/internal/api/v1/models/vote.go
+++ b/backend/internal/api/v1/models/vote.go
@@ -1,0 +1,62 @@
+package models
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+type SubmitBallotInput struct {
+	Body SubmitBallotBody
+}
+
+// president,secretary,treasurer,arc_delegate,edi_officer,grievance_officer
+
+var validPositions = map[string]struct{}{
+	"president":         {},
+	"secretary":         {},
+	"treasurer":         {},
+	"arc_delegate":      {},
+	"edi_officer":       {},
+	"grievance_officer": {},
+}
+
+var zIDRegex = regexp.MustCompile(`^z[0-9]{7}$`)
+
+type SubmitBallotBody struct {
+	Positions map[string]string `json:"positions" example:"{\"president\":\"z1234567\",\"secretary\":\"z7654321\"}"`
+}
+
+func (b *SubmitBallotInput) Resolve(ctx huma.Context) []error {
+	var errors []error
+
+	for position, zid := range b.Body.Positions {
+		if _, ok := validPositions[position]; !ok {
+			errors = append(errors, &huma.ErrorDetail{
+				Message:  "invalid position",
+				Location: "body.positions",
+				Value:    position,
+			})
+		}
+		if !zIDRegex.MatchString(zid) {
+			errors = append(errors, &huma.ErrorDetail{
+				Message:  "invalid zid format",
+				Location: "body.positions." + position,
+				Value:    zid,
+			})
+		}
+	}
+
+	return errors
+}
+
+type GetBallotResponse struct {
+	Body Ballot
+}
+
+type Ballot struct {
+	Positions map[string]string `json:"positions" example:"{\"president\":\"z1234567\",\"secretary\":\"z7654321\"}"`
+	CreatedAt time.Time            `json:"created_at" format:"date-time" example:"2024-01-15T10:30:00Z"`
+	UpdatedAt time.Time            `json:"updated_at" format:"date-time" example:"2024-01-15T10:30:00Z"`
+}

--- a/backend/internal/api/v1/routes.go
+++ b/backend/internal/api/v1/routes.go
@@ -103,6 +103,15 @@ func Register(api huma.API, deps HandlerDependencies) {
 		Tags:        []string{"Nominations"},
 	}, handlers.GetNomination(deps.Logger, deps.NominationStore, deps.ElectionStore))
 
+	huma.Register(userRoutes, huma.Operation{
+		OperationID: "delete-nomination",
+		Method:      http.MethodDelete,
+		Path:        "/nomination",
+		Summary:     "Delete self-nomination",
+		Description: "Deletes an existing self-nomination for the current election. If an election is running, this route will always return as it succeeded even if a nomination did not exist.",
+		Tags:        []string{"Nominations"},
+	}, handlers.DeleteNomination(deps.Logger, deps.NominationStore, deps.ElectionStore))
+	
 	// huma.Register(userRoutes, huma.Operation{
 	// 	OperationID: "get-ballot",
 	// 	Method:      "GET",

--- a/backend/internal/api/v1/routes.go
+++ b/backend/internal/api/v1/routes.go
@@ -7,13 +7,11 @@ import (
 	"github.com/alexliesenfeld/health"
 	"github.com/linuxunsw/vote/backend/internal/api/v1/handlers"
 	"github.com/linuxunsw/vote/backend/internal/api/v1/middleware"
-	"github.com/linuxunsw/vote/backend/internal/api/v1/models"
 	"github.com/linuxunsw/vote/backend/internal/config"
 	"github.com/linuxunsw/vote/backend/internal/mailer"
 	"github.com/linuxunsw/vote/backend/internal/store"
 
 	"github.com/danielgtaylor/huma/v2"
-	"github.com/danielgtaylor/huma/v2/sse"
 )
 
 type HandlerDependencies struct {
@@ -65,7 +63,7 @@ func Register(api huma.API, deps HandlerDependencies) {
 	userRoutes.UseMiddleware(authMiddleware)
 
 	// state updates via SSE
-	sse.Register(userRoutes, huma.Operation{
+	/* sse.Register(userRoutes, huma.Operation{
 		OperationID: "state",
 		Method:      http.MethodGet,
 		Path:        "/state",
@@ -75,7 +73,16 @@ func Register(api huma.API, deps HandlerDependencies) {
 	}, map[string]any{
 		"stateChange": &models.StateChangeEvent{},
 	},
-		handlers.GetState(deps.Logger))
+		handlers.GetState(deps.Logger)) */
+
+	// election state
+	huma.Register(userRoutes, huma.Operation{
+		OperationID: "get-election-state",
+		Method:      "GET",
+		Path:        "/state",
+		Summary:     "Get the current election state",
+		Tags:        []string{"State"},
+	}, handlers.GetElectionState(deps.Logger, deps.ElectionStore))
 
 	// nomination
 	huma.Register(userRoutes, huma.Operation{
@@ -136,18 +143,10 @@ func Register(api huma.API, deps HandlerDependencies) {
 	huma.Register(adminRoutes, huma.Operation{
 		OperationID: "admin-transition-election-state",
 		Method:      "PUT",
-		Path:        "/elections/state",
+		Path:        "/state",
 		Summary:     "Transition the election state",
 		Tags:        []string{"Admin"},
 	}, handlers.TransitionElectionState(deps.Logger, deps.ElectionStore))
-
-	huma.Register(adminRoutes, huma.Operation{
-		OperationID: "admin-get-election-state",
-		Method:      "GET",
-		Path:        "/elections/state",
-		Summary:     "Get the current election state",
-		Tags:        []string{"Admin"},
-	}, handlers.GetElectionState(deps.Logger, deps.ElectionStore))
 
 	// huma.Register(adminRoutes, huma.Operation{
 	// 	OperationID: "admin-upload-members",

--- a/backend/internal/api/v1/routes.go
+++ b/backend/internal/api/v1/routes.go
@@ -117,7 +117,7 @@ func Register(api huma.API, deps HandlerDependencies) {
 		OperationID: "get-public-nomination",
 		Method:      "GET",
 		Path:        "/nomination/{nomination_id}",
-		Summary:     "Delete a public nomination by ID",
+		Summary:     "Get a public nomination by ID",
 		Tags:        []string{"Nominations"},
 	}, handlers.GetPublicNomination(deps.Logger, deps.NominationStore))
 

--- a/backend/internal/api/v1/routes.go
+++ b/backend/internal/api/v1/routes.go
@@ -26,6 +26,7 @@ type HandlerDependencies struct {
 	OtpStore store.OTPStore
 	ElectionStore store.ElectionStore
 	NominationStore store.NominationStore
+	BallotStore store.BallotStore
 }
 
 // Register mounts all the API v1 routes using Huma groups and middleware.
@@ -112,21 +113,30 @@ func Register(api huma.API, deps HandlerDependencies) {
 		Tags:        []string{"Nominations"},
 	}, handlers.DeleteNomination(deps.Logger, deps.NominationStore, deps.ElectionStore))
 	
-	// huma.Register(userRoutes, huma.Operation{
-	// 	OperationID: "get-ballot",
-	// 	Method:      "GET",
-	// 	Path:        "/voting/ballot",
-	// 	Summary:     "Get the voting ballot",
-	// 	Tags:        []string{"Voting"},
-	// }, handlers.GetBallot(store))
-	//
-	// huma.Register(userRoutes, huma.Operation{
-	// 	OperationID: "submit-vote",
-	// 	Method:      "POST",
-	// 	Path:        "/voting/vote",
-	// 	Summary:     "Submit or update a vote",
-	// 	Tags:        []string{"Voting"},
-	// }, handlers.SubmitVote(store))
+	// voting
+	huma.Register(userRoutes, huma.Operation{
+		OperationID: "get-ballot",
+		Method:      "GET",
+		Path:        "/vote",
+		Summary:     "Get your voting ballot",
+		Tags:        []string{"Voting"},
+	}, handlers.GetBallot(deps.Logger, deps.BallotStore, deps.ElectionStore))
+	
+	huma.Register(userRoutes, huma.Operation{
+		OperationID: "submit-ballot",
+		Method:      "PUT",
+		Path:        "/vote",
+		Summary:     "Submit or update a voting ballot",
+		Tags:        []string{"Voting"},
+	}, handlers.SubmitBallot(deps.Logger, deps.BallotStore, deps.ElectionStore, deps.NominationStore))
+
+	huma.Register(userRoutes, huma.Operation{
+		OperationID: "delete-ballot",
+		Method:      "DELETE",
+		Path:        "/vote",
+		Summary:     "Delete your voting ballot",
+		Tags:        []string{"Voting"},
+	}, handlers.DeleteBallot(deps.Logger, deps.BallotStore, deps.ElectionStore))
 
 	// == Admin Routes ==
 	// This group requires a valid JWT AND admin privileges.

--- a/backend/internal/api/v1/routes.go
+++ b/backend/internal/api/v1/routes.go
@@ -117,7 +117,7 @@ func Register(api huma.API, deps HandlerDependencies) {
 		OperationID: "get-public-nomination",
 		Method:      "GET",
 		Path:        "/nomination/{nomination_id}",
-		Summary:     "Delete get a public nomination by ID",
+		Summary:     "Delete a public nomination by ID",
 		Tags:        []string{"Nominations"},
 	}, handlers.GetPublicNomination(deps.Logger, deps.NominationStore))
 

--- a/backend/internal/api/v1/routes.go
+++ b/backend/internal/api/v1/routes.go
@@ -112,31 +112,48 @@ func Register(api huma.API, deps HandlerDependencies) {
 		Description: "Deletes an existing self-nomination for the current election. If an election is running, this route will always return as it succeeded even if a nomination did not exist.",
 		Tags:        []string{"Nominations"},
 	}, handlers.DeleteNomination(deps.Logger, deps.NominationStore, deps.ElectionStore))
-	
+
+	huma.Register(userRoutes, huma.Operation{
+		OperationID: "get-public-nomination",
+		Method:      "GET",
+		Path:        "/nomination/{nomination_id}",
+		Summary:     "Delete get a public nomination by ID",
+		Tags:        []string{"Nominations"},
+	}, handlers.GetPublicNomination(deps.Logger, deps.NominationStore))
+
 	// voting
+	huma.Register(userRoutes, huma.Operation{
+		OperationID: "get-vote",
+		Method:      "GET",
+		Path:        "/vote",
+		Summary:     "Get your current vote",
+		Tags:        []string{"Voting"},
+	}, handlers.GetVote(deps.Logger, deps.BallotStore, deps.ElectionStore))
+	
+	huma.Register(userRoutes, huma.Operation{
+		OperationID: "submit-vote",
+		Method:      "PUT",
+		Path:        "/vote",
+		Summary:     "Submit or update your current vote",
+		Tags:        []string{"Voting"},
+	}, handlers.SubmitVote(deps.Logger, deps.BallotStore, deps.ElectionStore, deps.NominationStore))
+
+	huma.Register(userRoutes, huma.Operation{
+		OperationID: "delete-vote",
+		Method:      "DELETE",
+		Path:        "/vote",
+		Summary:     "Delete your current vote",
+		Tags:        []string{"Voting"},
+	}, handlers.DeleteVote(deps.Logger, deps.BallotStore, deps.ElectionStore))
+
+	// ballot
 	huma.Register(userRoutes, huma.Operation{
 		OperationID: "get-ballot",
 		Method:      "GET",
-		Path:        "/vote",
-		Summary:     "Get your voting ballot",
+		Path:        "/ballot",
+		Summary:     "Get the current ballot",
 		Tags:        []string{"Voting"},
-	}, handlers.GetBallot(deps.Logger, deps.BallotStore, deps.ElectionStore))
-	
-	huma.Register(userRoutes, huma.Operation{
-		OperationID: "submit-ballot",
-		Method:      "PUT",
-		Path:        "/vote",
-		Summary:     "Submit or update a voting ballot",
-		Tags:        []string{"Voting"},
-	}, handlers.SubmitBallot(deps.Logger, deps.BallotStore, deps.ElectionStore, deps.NominationStore))
-
-	huma.Register(userRoutes, huma.Operation{
-		OperationID: "delete-ballot",
-		Method:      "DELETE",
-		Path:        "/vote",
-		Summary:     "Delete your voting ballot",
-		Tags:        []string{"Voting"},
-	}, handlers.DeleteBallot(deps.Logger, deps.BallotStore, deps.ElectionStore))
+	}, handlers.GetBallot(deps.Logger, deps.BallotStore, deps.ElectionStore, deps.NominationStore))
 
 	// == Admin Routes ==
 	// This group requires a valid JWT AND admin privileges.

--- a/backend/internal/store/ballot_store.go
+++ b/backend/internal/store/ballot_store.go
@@ -1,0 +1,29 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+type SubmitBallot struct {
+	Positions map[string]string `db:"positions"`
+}
+
+type Ballot struct {
+	Positions map[string]string `db:"positions"`
+
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
+}
+
+type BallotStore interface {
+	// Submit or replace an existing ballot for the given election and voter zid.
+	// Does not perform validation of the submission.
+	SubmitOrReplaceBallot(ctx context.Context, electionID string, zid string, submission SubmitBallot) error
+
+	// Get a ballot by election ID and voter zID. Returns nil if not found.
+	GetBallot(ctx context.Context, electionID string, zid string) (*Ballot, error)
+
+	// Delete a ballot by election ID and voter zID. Does nothing if the ballot doesn't exist.
+	TryDeleteBallot(ctx context.Context, electionID string, zid string) error
+}

--- a/backend/internal/store/migrations/00005_ballot.sql
+++ b/backend/internal/store/migrations/00005_ballot.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+create table "ballots" (
+    "election_id" uuid,
+    "zid" text,
+    
+	-- {"position": "candidate_zid", "position2": "candidate_zid2", ...}
+    "positions" JSONB not null,
+
+    "created_at" timestamptz not null,
+    "updated_at" timestamptz not null,
+
+    primary key ("election_id", "zid")
+);
+
+-- +goose Down
+drop table "ballots";

--- a/backend/internal/store/migrations/00006_nomination_id.sql
+++ b/backend/internal/store/migrations/00006_nomination_id.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+alter table "nominations" add column "nomination_id" uuid;
+
+alter table "nominations" drop constraint if exists nominations_pkey;
+
+alter table "nominations"
+add constraint nominations_election_candidate_key unique (election_id, candidate_zid);
+
+alter table "nominations"
+add constraint nominations_pkey primary key ("nomination_id");
+
+-- +goose Down
+alter table "nominations"
+drop constraint if exists nominations_pkey;
+
+alter table "nominations"
+drop constraint if exists nominations_election_candidate_key;
+
+alter table "nominations"
+drop column if exists nomination_id;
+
+alter table "nominations"
+add constraint nominations_pkey primary key (election_id, candidate_zid);

--- a/backend/internal/store/nomination_store.go
+++ b/backend/internal/store/nomination_store.go
@@ -18,6 +18,15 @@ type Nomination struct {
 	UpdatedAt          time.Time   `db:"updated_at" json:"updated_at" format:"date-time" example:"2024-01-15T10:30:00Z"`
 }
 
+func (nom Nomination) IsRunningFor(role string) bool {
+	for _, r := range nom.ExecutiveRoles {
+		if r == role {
+			return true
+		}
+	}
+	return false
+}
+
 type SubmitNomination struct {
 	CandidateName      string   `db:"candidate_name" json:"candidate_name" minLength:"2" maxLength:"100" example:"John Doe"`
 	ContactEmail       string   `db:"contact_email" json:"contact_email" format:"email" example:"john@example.com"`

--- a/backend/internal/store/nomination_store.go
+++ b/backend/internal/store/nomination_store.go
@@ -33,4 +33,7 @@ type NominationStore interface {
 
 	// Get a nomination by election ID and candidate zID. Returns nil if not found.
 	GetNomination(ctx context.Context, electionID string, candidateZid string) (*Nomination, error)
+
+	// Delete a nomination by election ID and candidate zID. Does nothing if the nomination doesn't exist.
+	TryDeleteNomination(ctx context.Context, electionID string, candidateZid string) error
 }

--- a/backend/internal/store/nomination_store.go
+++ b/backend/internal/store/nomination_store.go
@@ -6,16 +6,17 @@ import (
 )
 
 type Nomination struct {
-	ElectionID         string   `db:"election_id" json:"election_id" example:"1"`
-	CandidateZID       string   `db:"candidate_zid" json:"candidate_zid" example:"z1234567"`
-	CandidateName      string   `db:"candidate_name" json:"candidate_name" example:"John Doe"`
-	ContactEmail       string   `db:"contact_email" json:"contact_email" example:"john@example.com"`
-	DiscordUsername    string   `db:"discord_username" json:"discord_username" example:"johndoe"`
-	ExecutiveRoles     []string `db:"executive_roles" json:"executive_roles" example:"[\"president\", \"secretary\"]"`
-	CandidateStatement string   `db:"candidate_statement" json:"candidate_statement" example:"I am running for president because..."`
-	URL                *string  `db:"url" json:"url,omitempty" example:"https://johndoe.com"`
-	CreatedAt          time.Time   `db:"created_at" json:"created_at" format:"date-time" example:"2024-01-15T10:30:00Z"`
-	UpdatedAt          time.Time   `db:"updated_at" json:"updated_at" format:"date-time" example:"2024-01-15T10:30:00Z"`
+	NominationId       string    `db:"nomination_id" json:"nomination_id"`
+	ElectionID         string    `db:"election_id" json:"election_id"`
+	CandidateZID       string    `db:"candidate_zid" json:"candidate_zid" example:"z1234567"`
+	CandidateName      string    `db:"candidate_name" json:"candidate_name" example:"John Doe"`
+	ContactEmail       string    `db:"contact_email" json:"contact_email" example:"john@example.com"`
+	DiscordUsername    string    `db:"discord_username" json:"discord_username" example:"johndoe"`
+	ExecutiveRoles     []string  `db:"executive_roles" json:"executive_roles" example:"[\"president\", \"secretary\"]"`
+	CandidateStatement string    `db:"candidate_statement" json:"candidate_statement" example:"I am running for president because..."`
+	URL                *string   `db:"url" json:"url,omitempty" example:"https://johndoe.com"`
+	CreatedAt          time.Time `db:"created_at" json:"created_at" format:"date-time" example:"2024-01-15T10:30:00Z"`
+	UpdatedAt          time.Time `db:"updated_at" json:"updated_at" format:"date-time" example:"2024-01-15T10:30:00Z"`
 }
 
 func (nom Nomination) IsRunningFor(role string) bool {
@@ -37,12 +38,18 @@ type SubmitNomination struct {
 }
 
 type NominationStore interface {
-	// Create or replace a new nomination.
-	SubmitOrReplaceNomination(ctx context.Context, electionID string, candidateZid string, submission SubmitNomination) error
+	// Create or replace a new nomination. Returns the public nomination ID.
+	SubmitOrReplaceNomination(ctx context.Context, electionID string, candidateZid string, submission SubmitNomination) (string, error)
 
 	// Get a nomination by election ID and candidate zID. Returns nil if not found.
-	GetNomination(ctx context.Context, electionID string, candidateZid string) (*Nomination, error)
+	GetNomination(ctx context.Context, electionId string, candidateZid string) (*Nomination, error)
+
+	// Get a nomination by the public nomination ID. Returns nil if not found.
+	GetNominationByPublicId(ctx context.Context, nominationId string) (*Nomination, error)
+
+	// Get all nominations for an election. Returns nil if not found.
+	GetElectionNominations(ctx context.Context, electionId string) ([]Nomination, error)
 
 	// Delete a nomination by election ID and candidate zID. Does nothing if the nomination doesn't exist.
-	TryDeleteNomination(ctx context.Context, electionID string, candidateZid string) error
+	TryDeleteNomination(ctx context.Context, electionId string, candidateZid string) error
 }

--- a/backend/internal/store/pg/ballot.go
+++ b/backend/internal/store/pg/ballot.go
@@ -1,0 +1,76 @@
+package pg
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/linuxunsw/vote/backend/internal/store"
+)
+
+type PgBallotStore struct {
+	// *pgx.Pool
+	pool PgxPoolIface
+
+	NowProvider func() time.Time
+}
+
+func NewPgBallotStore(pool PgxPoolIface) store.BallotStore {
+	return &PgBallotStore{
+		pool: pool,
+
+		NowProvider: time.Now,
+	}
+}
+
+func (b *PgBallotStore) SubmitOrReplaceBallot(ctx context.Context, electionID string, zid string, submission store.SubmitBallot) error {
+	submissionObject, err := json.Marshal(submission.Positions)
+	if err != nil {
+		return err
+	}
+	
+	// Upsert the ballot
+	_, err = b.pool.Exec(ctx, `
+		insert into ballots (election_id, zid, positions, created_at, updated_at)
+		values ($1, $2, $3, $4, $4)
+		on conflict (election_id, zid) do update
+			set positions = $3, updated_at = $4
+	`, electionID, zid, string(submissionObject), b.NowProvider())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *PgBallotStore) GetBallot(ctx context.Context, electionID string, zid string) (*store.Ballot, error) {
+	rows, err := b.pool.Query(ctx, `
+		select positions, created_at, updated_at
+		from ballots
+		where election_id = $1 and zid = $2
+	`, electionID, zid)
+	if err != nil {
+		return nil, err
+	}
+
+	ballot, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[store.Ballot])
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &ballot, nil
+}
+
+func (b *PgBallotStore) TryDeleteBallot(ctx context.Context, electionID string, zid string) error {
+	_, err := b.pool.Exec(ctx, `
+		delete from ballots
+		where election_id = $1 and zid = $2
+	`, electionID, zid)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/backend/internal/store/pg/nomination.go
+++ b/backend/internal/store/pg/nomination.go
@@ -79,3 +79,11 @@ func (st *PgNominationStore) GetNomination(ctx context.Context, electionID strin
 
 	return &entry, nil
 }
+
+func (st *PgNominationStore) TryDeleteNomination(ctx context.Context, electionID string, candidateZid string) error {
+	_, err := st.pool.Exec(ctx, `
+		delete from nominations
+		where election_id = $1 and candidate_zid = $2
+	`, electionID, candidateZid)
+	return err
+}


### PR DESCRIPTION
Implemented `GET`, `PUT`, `DELETE` for voting ballots. A ballot is simply a key value object from positions -> candidate zIDs. The correct validation is performed to not allow bogus positions, and ensuring that a candidate is actually running for that position at the time the vote was submitted. Testing has been implemented.

You are allowed to submit empty ballots, or even not fill out each position to a candidate.

Nomination `DELETE` has also been implemented. At the time being, nothing is done to handle adjusting ballots to remove votes for people that have dropped out/`DELETE`ed their nomination.

The `/elections/state` has been moved to `/state` to replace the existing SSE route. We need to decide what we want to do with the SSE route.

---

Public nomination IDs are implemented, with hiding of emails and zIDs. For your own nomination, you access and edit your nomination by token. For public users, you access `GET /ballot` to get nomination IDs, and you can access them individually for whatever reason by `GET /nomination/{nomination_id}`. A nomination ID isn't particularly useful at all for managing your own nomination.